### PR TITLE
Fix invalid deckgl output file location

### DIFF
--- a/ees/README.release.txt
+++ b/ees/README.release.txt
@@ -9,8 +9,8 @@ Copyright (C) 2014-2019 by its authors.
 To run the included example scenario do:
 
 ```
-java -Xms2g -Xmx2g \
-  -cp libs/*:eeslib-2.1.1-SNAPSHOT.jar \
-  io.github.agentsoz.ees.Run \
+java -Xms2g -Xmx2g \                 
+   -cp $(find libs/ -name "*.jar" | tr '\n' ':./'):eeslib-2.1.1-SNAPSHOT.jar \
+   io.github.agentsoz.ees.Run \
   --config scenarios/mount-alexander-shire/maldon-example/ees.xml
 ```

--- a/ees/scenarios/mount-alexander-shire/maldon-example/ees.xml
+++ b/ees/scenarios/mount-alexander-shire/maldon-example/ees.xml
@@ -37,7 +37,7 @@
     <!-- simulation start time in HH:MM format -->
     <opt id="startHHMM">12:00</opt>
     <!-- Output file for trips written in DeckGL format -->
-    <opt id="deckGlOutFile">test/output/io/github/agentsoz/ees/agents/MaldonExample/test/trips.deckgl.json</opt>
+    <opt id="deckGlOutFile">test/output/io/github/agentsoz/ees/agents/archetype/MaldonExample/test/trips.deckgl.json</opt>
   </global>
 
   <!-- model specific configuration -->


### PR DESCRIPTION
Fixes the location of "deckGlOutFile" in the maldon example `ees.xml` which is included
in the release archive. 

**Changelog** 
 - Changes the file output location to "agents/archetype/MaldonExample" from
   "agents/MaldonExample". This was causing this example run to fail as the
   directory doesn't exist.  
 - Updates the release README command's classpath


